### PR TITLE
Prevent creating empty directories

### DIFF
--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -415,7 +415,6 @@ class Package extends Command {
 			}
 
 			if ( $item->isDir() ) {
-				$filesystem->mkdir( $destination . DIRECTORY_SEPARATOR . $path );
 				continue;
 			}
 


### PR DESCRIPTION
When files are synced from the build directory to the zip directory, if the include/exclude rules would have resulted in an empty directory, that empty directory would be created and included in the ZIP.

By just skipping over any directories in the iterator, we prevent that from happening.

If the directory needs to be created, it is being created just before the file is written anyway.