### PR TITLE
Fix default distignore

### DIFF
--- a/.distignore-defaults
+++ b/.distignore-defaults
@@ -17,8 +17,6 @@ codeception.*
 .wordpress-org
 bun.lockb
 
-bin
-tests
 vendor/bin
 vendor/composer/installers
 vendor/stellarwp/pup

--- a/.distignore-defaults
+++ b/.distignore-defaults
@@ -17,6 +17,8 @@ codeception.*
 .wordpress-org
 bun.lockb
 
+bin/
+tests/
 vendor/bin
 vendor/composer/installers
 vendor/stellarwp/pup


### PR DESCRIPTION
Fix the default `distignore` to avoid skipping files with `bin` and `tests` in their name. 