### PR TITLE
Adds missing `--dev` docs for `pup check`

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,9 +63,10 @@ composer -- pup check
 ```
 
 ### Arguments
-| Argument | Description                                                                  |
-|----------|------------------------------------------------------------------------------|
-| `--root` | **Optional.** Run the command from a different directory from the current.   |
+| Argument | Description                                                                                                                                        |
+|----------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `--root` | **Optional.** Run the command from a different directory from the current.                                                                         |
+| `--dev`  | **Optional.** Run the command with with an alternate faliure method. This alternate method is set as `fail_method_dev` for each Check in `.puprc`. |
 
 ### `pup check:tbd`
 Scans your files for `tbd` (case-insensitive) and tells you where to find them.


### PR DESCRIPTION
Was looking into something yesterday with `pup check` and realized that `--dev` wasn't documented as part of the main `pup check` docs.

This should help clarify that it is an argument for `pup check` and describe how it is used by each Check.