### PR TITLE
Create a default PUP User-Agent as WP.org blocks Guzzle.

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -23,4 +23,4 @@ parameters:
 
 	ignoreErrors:
 		- '#^Constant __PUP_DIR__ not found\.$#'
-		- '#^Constant PUP_VERSION not found\.$#'
+		- '#^Constant (.*)PUP_VERSION not found\.$#'

--- a/src/Commands/I18n.php
+++ b/src/Commands/I18n.php
@@ -63,6 +63,20 @@ class I18n extends Command {
 	}
 
 	/**
+	 * Returns default client options.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	protected function get_default_client_options() {
+		$version = \StellarWP\Pup\PUP_VERSION;
+		return [
+			'headers' => [
+				'User-Agent' => "StellarWP PUP/{$version}",
+			],
+		];
+	}
+
+	/**
 	 * Downloads language files.
 	 *
 	 * @param I18nConfig $i18n_config
@@ -85,7 +99,7 @@ class I18n extends Command {
 
 		$io->writeln( "<fg=yellow>Fetching language files for {$options->text_domain} from {$options->url}</>" ); // @phpstan-ignore-line: Those are strings.
 
-		$client = new Client();
+		$client = new Client( $this->get_default_client_options() );
 
 		$project_url = $options->url . '/api/projects/' . $options->slug;
 		$project_res = $client->request( 'GET', $project_url );
@@ -150,7 +164,7 @@ class I18n extends Command {
 
 		$tried++;
 
-		$client  = new Client();
+		$client  = new Client( $this->get_default_client_options() );
 		$request = new Request( 'GET', $translation_url );
 
 		$promise = $client->sendAsync( $request )->then( function ( $response ) use ( $translation_url, $options, $translation, $format, $project_url, $tried, $io  ) {

--- a/src/Commands/I18n.php
+++ b/src/Commands/I18n.php
@@ -5,6 +5,7 @@ namespace StellarWP\Pup\Commands;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Request;
 use StellarWP\Pup\App;
+use StellarWP\Pup;
 use StellarWP\Pup\Command\Command;
 use StellarWP\Pup\I18nConfig;
 use Symfony\Component\Console\Input\InputInterface;
@@ -68,7 +69,7 @@ class I18n extends Command {
 	 * @return array<string, array<string, string>>
 	 */
 	protected function get_default_client_options() {
-		$version = \StellarWP\Pup\PUP_VERSION;
+		$version = Pup\PUP_VERSION;
 		return [
 			'headers' => [
 				'User-Agent' => "StellarWP PUP/{$version}",


### PR DESCRIPTION
Resolves #18 

![screenshot-2024-04-28-00-22-01](https://github.com/stellarwp/pup/assets/236579/174e8eda-dd76-4abe-8b0a-ce520dc63372)
