### PR TITLE
DOCS: Fix workflows example

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -278,7 +278,7 @@ An example workflow might look like this:
 
 ```json
 {
-    "workflow": {
+    "workflows": {
         "my-workflow": [
             "npm ci",
             "npm run build",


### PR DESCRIPTION
The workflow documentation is missing an `s` in the example.