### PR TITLE
Show Workflow complete message after all steps are complete

### DIFF
--- a/src/Commands/Workflow.php
+++ b/src/Commands/Workflow.php
@@ -88,9 +88,9 @@ class Workflow extends Command {
 			if ( $root ) {
 				chdir( $config->getWorkingDir() );
 			}
-
-			$io->writeln( '<success>Workflow complete.</success>' );
 		}
+
+		$io->writeln( '<success>Workflow complete.</success>' );
 
 		return 0;
 	}


### PR DESCRIPTION
Currently, this shows `Workflow complete.` after each _workflow step_ instead of after all the steps have completed.