### PR TITLE
Allow arguments and options to be passed through to workflow scripts

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -37,6 +37,58 @@ pup workflow my-workflow
 pup do my-workflow
 ```
 
+### Pass additional arguments or options to a workflow
+
+You can pass through additional arguments and options to your workflow script.
+
+Example `test-script.sh`:
+```bash
+#!/usr/bin/env bash
+
+# Loop through all the arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --*=*) # Option in --option=value format
+      option="${1%%=*}"  # Extract the option
+      value="${1#*=}"    # Extract the value
+      echo "Option: $option, Value: $value"
+      shift
+      ;;
+    --*) # Option in --option format (expecting a separate value)
+      option=$1
+      shift
+      if [[ "$1" && ! "$1" =~ ^-- ]]; then
+        value=$1
+        echo "Option: $option, Value: $value"
+        shift
+      else
+        echo "Option: $option, No value provided"
+      fi
+      ;;
+    *) # Regular argument
+      echo "Argument: $1"
+      shift
+      ;;
+  esac
+done
+```
+
+Example in `.puprc`:
+```json
+{
+    "workflows": {
+        "my-test-workflow": [
+            "./test-script.sh"
+        ]
+    }
+}
+```
+
+Pass through arguments and options to `test-script.sh`:
+```bash
+pup workflow my-test-workflow -- arg1 arg2 otherArg --option-one=test1 --option-two=test2
+```
+
 ## Pseudo-workflows
 
 The `build` and `build_dev` properties within your `.puprc` file are also callable via the `workflow` command.

--- a/tests/_data/test-workflow-script.sh
+++ b/tests/_data/test-workflow-script.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# A test workflow run via the test suite
+
+# Loop through all the arguments
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --*=*) # Option in --option=value format
+      option="${1%%=*}"  # Extract the option
+      value="${1#*=}"    # Extract the value
+      echo "Option: $option, Value: $value"
+      shift
+      ;;
+    --*) # Option in --option format (expecting a separate value)
+      option=$1
+      shift
+      if [[ "$1" && ! "$1" =~ ^-- ]]; then
+        value=$1
+        echo "Option: $option, Value: $value"
+        shift
+      else
+        echo "Option: $option, No value provided"
+      fi
+      ;;
+    *) # Regular argument
+      echo "Argument: $1"
+      shift
+      ;;
+  esac
+done

--- a/tests/cli/Commands/Checks/__snapshots__/TbdCest__it_should_run_fail_tbd_check_when_tbds_exist__0.snapshot.txt
+++ b/tests/cli/Commands/Checks/__snapshots__/TbdCest__it_should_run_fail_tbd_check_when_tbds_exist__0.snapshot.txt
@@ -2,9 +2,6 @@
 Checking for TBDs...
 --------------------
 
-./src/Plugin.php
-9: * @since TBD
-
 ./src/Thing/AnotherFile.php
 5: _deprecated_file( __FILE__, 'TBD' );
 9: * @since TBD
@@ -13,6 +10,9 @@ Checking for TBDs...
 19: * @version tbd
 28: * @deprecated TBD
 32: _deprecated_function( __METHOD__, 'TBD' );
+
+./src/Plugin.php
+9: * @since TBD
 
 
 TBDs have been found!

--- a/tests/cli/Commands/WorkflowCest.php
+++ b/tests/cli/Commands/WorkflowCest.php
@@ -181,7 +181,7 @@ class WorkflowCest extends AbstractBase {
 		$puprc['workflows']['test-workflow'][] = codecept_data_dir( 'test-workflow-script.sh' );
 		$this->write_puprc( $puprc );
 
-		chdir( $this->tests_root . '/_data/fake-project' );
+		chdir( codecept_data_dir( 'fake-project' ) );
 
 		$I->runShellCommand( "php {$this->pup} do test-workflow -- arg1 arg2 --option-one=one --option-two=two" );
 		$I->seeResultCodeIs( 0 );

--- a/tests/cli/Commands/WorkflowCest.php
+++ b/tests/cli/Commands/WorkflowCest.php
@@ -170,4 +170,27 @@ class WorkflowCest extends AbstractBase {
 		$output = $I->grabShellOutput();
 		$this->assertMatchesStringSnapshot( $output );
 	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_pass_additional_arguments_and_options_to_workflow_script( CliTester $I ) {
+		$puprc                                 = $this->get_puprc();
+		$puprc['workflows']                    = [];
+		$puprc['workflows']['test-workflow']   = [];
+		$puprc['workflows']['test-workflow'][] = codecept_data_dir( 'test-workflow-script.sh' );
+		$this->write_puprc( $puprc );
+
+		chdir( $this->tests_root . '/_data/fake-project' );
+
+		$I->runShellCommand( "php {$this->pup} do test-workflow -- arg1 arg2 --option-one=one --option-two=two" );
+		$I->seeResultCodeIs( 0 );
+		$I->seeInShellOutput( 'Argument: arg1' );
+		$I->seeInShellOutput( 'Argument: arg2' );
+		$I->seeInShellOutput( 'Option: --option-one, Value: one' );
+		$I->seeInShellOutput( 'Option: --option-two, Value: two' );
+
+		$output = $I->grabShellOutput();
+		$this->assertMatchesStringSnapshot( $output );
+	}
 }

--- a/tests/cli/Commands/__snapshots__/WorkflowCest__it_should_pass_additional_arguments_and_options_to_workflow_script__0.snapshot.txt
+++ b/tests/cli/Commands/__snapshots__/WorkflowCest__it_should_pass_additional_arguments_and_options_to_workflow_script__0.snapshot.txt
@@ -1,0 +1,11 @@
+Running test-workflow workflow steps...
+
+> /var/www/html/wp-content/plugins/pup/tests/_data/test-workflow-script.sh 'arg1' 'arg2' '--option-one=one' '--option-two=two'
+------------------------------------------------------------------------------------------------------------------------------
+
+Argument: arg1
+Argument: arg2
+Option: --option-one, Value: one
+Option: --option-two, Value: two
+
+Workflow complete.


### PR DESCRIPTION
### Main Changes

Allow arguments and options to be passed through to underlying workflow commands, e.g.

```bash
composer -- pup workflow set-version -- arg1 arg2 otherArg --option-one=test1 --option-two=test2
```

![image](https://github.com/user-attachments/assets/2c923671-3e4e-4b81-8e8a-f09c2dec8a7d)
