### PR TITLE
Ensure that included files are actually included

### DIFF
--- a/pup
+++ b/pup
@@ -3,7 +3,7 @@
 
 namespace StellarWP\Pup;
 
-const PUP_VERSION = '1.3.7';
+const PUP_VERSION = '1.3.8';
 define( '__PUP_DIR__', __DIR__ );
 
 if ( ! \Phar::running() ) {

--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -406,11 +406,17 @@ class Package extends Command {
 		foreach ( $iterator as $item ) {
 			$path = ltrim( $iterator->getSubPathName(), '/\\' );
 
-			if ( ! $this->isIncludedFile( $path, $include ) ) {
+			if ( strpos( $path, '.pup' ) !== false ) {
 				continue;
 			}
 
-			if ( $this->isIgnoredFile( $path, $ignore ) ) {
+			$is_included_file = $this->isIncludedFile( $path, $include );
+
+			if ( ! $is_included_file ) {
+				continue;
+			}
+
+			if ( ! $is_included_file && $this->isIgnoredFile( $path, $ignore ) ) {
 				continue;
 			}
 

--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -85,7 +85,7 @@ class Package extends Command {
 
 		$output->writeln( '<fg=gray>- Synchronizing files to zip directory...</>' );
 
-		$distfiles = $this->getDistfilesLines( $root );
+		$distfiles = $this->getDistfilesLines( $this->getSourceDir( $root ) );
 		if ( ! empty( $distfiles ) ) {
 			$distfiles_message = '>>> Your project has a <fg=yellow>.distfiles</> file, so <fg=yellow>.distignore</> and pup\'s default ignore rules will not be used.';
 			$output->writeln( "<fg=gray>{$distfiles_message}</>" );

--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -84,6 +84,13 @@ class Package extends Command {
 		$output->writeln( '<fg=green>✓</> Updating version files...Complete.' );
 
 		$output->writeln( '<fg=gray>- Synchronizing files to zip directory...</>' );
+
+		$distfiles = $this->getDistfilesLines( $root );
+		if ( ! empty( $distfiles ) ) {
+			$distfiles_message = '>>> Your project has a <fg=yellow>.distfiles</> file, so <fg=yellow>.distignore</> and pup\'s default ignore rules will not be used.';
+			$output->writeln( "<fg=gray>{$distfiles_message}</>" );
+		}
+
 		$pup_zip_dir  = $config->getZipDir();
 
 		DirectoryUtils::rmdir( $pup_zip_dir );


### PR DESCRIPTION
This resolves an issue where an ignored file will supercede an explicit include.

Example:

1. If `.distfiles` includes `/node_modules/clipboard/**/*.min.js`
2. If `.distignore` includes `/node_modules`, it will override the above

The fix is a `.distfiles` exists and has contents, `.distignore` is not observed - because `.distfiles` a safelist of files with more flexibility than `.distignore` in its syntax.