### PR TITLE
Deprecate PHP Version: Fix `.distinclude` bug

### DIFF
--- a/src/Commands/Package.php
+++ b/src/Commands/Package.php
@@ -287,7 +287,7 @@ class Package extends Command {
 	 */
 	public function getDistincludeLines( string $source ): array {
 		$include      = [];
-		$include_file = '.pup-include';
+		$include_file = '.pup-distinclude';
 
 		if ( ! file_exists( $source . $include_file ) ) {
 			return [];

--- a/tests/cli/Commands/__snapshots__/PackageCest__it_should_not_let_distinclude_override_distignore_and_gitattributes__0.snapshot.txt
+++ b/tests/cli/Commands/__snapshots__/PackageCest__it_should_not_let_distinclude_override_distignore_and_gitattributes__0.snapshot.txt
@@ -1,0 +1,1 @@
+.pup-zip/fake-project

--- a/tests/cli/Commands/__snapshots__/PackageCest__it_should_package_the_zip_and_include_files_in_distinclude__0.snapshot.txt
+++ b/tests/cli/Commands/__snapshots__/PackageCest__it_should_package_the_zip_and_include_files_in_distinclude__0.snapshot.txt
@@ -1,3 +1,0 @@
-.
-..
-fake-project

--- a/tests/cli/Commands/__snapshots__/PackageCest__it_should_package_the_zip_and_include_files_in_distinclude_even_if_in_distignore_and_gitattributes__0.snapshot.txt
+++ b/tests/cli/Commands/__snapshots__/PackageCest__it_should_package_the_zip_and_include_files_in_distinclude_even_if_in_distignore_and_gitattributes__0.snapshot.txt
@@ -1,3 +1,0 @@
-.
-..
-fake-project

--- a/tests/cli/Commands/__snapshots__/PackageCest__it_should_use_distinclude_as_a_filter_for_candidate_files__0.snapshot.txt
+++ b/tests/cli/Commands/__snapshots__/PackageCest__it_should_use_distinclude_as_a_filter_for_candidate_files__0.snapshot.txt
@@ -1,0 +1,1 @@
+.pup-zip/fake-project/bootstrap.php


### PR DESCRIPTION
:ticket: [ENG-222]

## Summary

While deprecating the PHP version, we may as well fix this bug I discovered in #47 to ensure full feature-parity. 

Fixes a naming inconsistency in the PHP codebase that made `.distinclude` non-functional, and strengthens tests to properly detect the bug.

- Corrects `getDistincludeLines()` to read from `.pup-distinclude` (matching what `DistInclude::writePup()` writes)
- Updates `.distinclude` tests to use `bootstrap.php`/`other-file.php` instead of `.puprc` (which is always in default ignores)
- Replaces weak `ls -a .pup-zip` assertions with `find` to verify actual zip file contents
- Adds `assertStringContainsString`/`assertStringNotContainsString` assertions for explicit verification

## The Bug

Each sync file type is written to a `.pup-*` intermediate file during packaging, then read back. The write side (`DistInclude` class) and read side (`Package::getDistincludeLines()`) used **different filenames** for `.distinclude`:

| Source file | Written to (PHP) | Read from (PHP) | Status |
|---|---|---|---|
| `.distfiles` | `.pup-distfiles` | `.pup-distfiles` | Working |
| `.distignore` | `.pup-distignore` | `.pup-distignore` | Working |
| `.gitattributes` | `.pup-distignore` | `.pup-distignore` | Working |
| `.distinclude` | `.pup-distinclude` | **`.pup-include`** | **Broken** |

Because `getDistincludeLines()` read from `.pup-include` but `DistInclude::writePup()` wrote to `.pup-distinclude`, the file was generated but never read back. This meant `.distinclude` patterns were **silently ignored** in every release.

### Why the tests didn't catch it

1. **Weak assertions**: Tests used `ls -a .pup-zip` which only listed the top-level directory (`fake-project`), never the files inside it. The snapshot matched regardless of whether `.distinclude` was functional.

2. **Testing with `.puprc`**: Both tests used `.puprc` as the file to include via `.distinclude`. But `.puprc` is always excluded by the hardcoded default ignore rules. This means `.puprc` would be absent from the zip whether `.distinclude` worked or not — the test could never distinguish between "`.distinclude` filtered correctly but ignore rules applied" and "`.distinclude` was silently ignored."

## Test Plan

- [x] Run the two `.distinclude` tests: `vendor/bin/codecept run cli 'Commands/PackageCest:it_should_use_distinclude' --steps` and `vendor/bin/codecept run cli 'Commands/PackageCest:it_should_not_let_distinclude' --steps` — both pass
- [x] Revert the fix (`sed -i 's/.pup-distinclude/.pup-include/' src/Commands/Package.php`) and re-run — `it_should_use_distinclude_as_a_filter_for_candidate_files` fails, confirming the test catches the bug
- [x] Run full PackageCest suite: `vendor/bin/codecept run cli 'Commands/PackageCest'` — all tests pass

[ENG-222]: https://stellarwp.atlassian.net/browse/ENG-222