### PR TITLE
Deprecate PHP Version: Fix .puprc parse check in info command

### DIFF
--- a/src/Commands/Info.php
+++ b/src/Commands/Info.php
@@ -54,7 +54,7 @@ class Info extends Command {
 			$suffix = 'does not exist';
 			$array_to_populate = 'files_absent';
 
-			if ( $exists && $file === '.puprc' && ! json_decode( $file ) ) {
+			if ( $exists && $file === '.puprc' && ! json_decode( file_get_contents( $file ) ) ) {
 				$prefix = '❌';
 				$suffix = '<fg=green>exists</> but could not be parsed: ' . json_last_error_msg();
 				$array_to_populate = 'files_error';

--- a/src/Commands/Info.php
+++ b/src/Commands/Info.php
@@ -54,7 +54,7 @@ class Info extends Command {
 			$suffix = 'does not exist';
 			$array_to_populate = 'files_absent';
 
-			if ( $exists && $file === '.puprc' && ! json_decode( file_get_contents( $file ) ) ) {
+			if ( $exists && $file === '.puprc' && ! json_decode( (string) file_get_contents( $file ) ) ) {
 				$prefix = '❌';
 				$suffix = '<fg=green>exists</> but could not be parsed: ' . json_last_error_msg();
 				$array_to_populate = 'files_error';


### PR DESCRIPTION
:ticket: [ENG-222]

## Summary
- Fix bug in `pup info` where the `.puprc` parse check was passing the filename string `'.puprc'` to `json_decode()` instead of reading the file contents first, causing it to always report a parse error even for valid `.puprc` files.

Discovered while working on the TypeScript rewrite of the info command in https://github.com/stellarwp/pup/pull/36.

## Test plan
- [x] Run `pup info` in a project with a valid `.puprc` file — should show ✅ `.puprc - exists`
- [x] Run `pup info` in a project with an invalid `.puprc` file (e.g. malformed JSON) — should show ❌ `.puprc - exists but could not be parsed: <error message>`
- [x] Run `pup info` in a project with no `.puprc` file — should show ⚫ `.puprc - does not exist`

[ENG-222]: https://stellarwp.atlassian.net/browse/ENG-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ