### PR TITLE
Improve i18n retry logic for rate-limited requests (HTTP 429)

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,6 +1,6 @@
 # Internationalization (i18n)
 
-The `pup i18n` command can be used do fetch language files from a GlotPress instance for your project. To enable this
+The `pup i18n` command can be used to fetch language files from a GlotPress instance for your project. To enable this
 command, you must configure the `i18n` section of your `.puprc` file.
 
 ## The bare minimum
@@ -41,7 +41,53 @@ will download language files to an alternate location:
 }
 ```
 
-## All options
+## Command-line options
+
+You can adjust the retry and rate-limit handling behavior when running `pup i18n`:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--retries` | `int` | `3` | Number of retries per translation file on failure (minimum 1, maximum 10). Use this to control how aggressive retries should be. |
+| `--delay` | `int` | `2` | Base delay in seconds between retries and for HTTP 429 rate-limit backoff (minimum 1). Increase this if you're hitting rate limits frequently. |
+| `--batch-size` | `int` | `3` | Batch size for grouping downloads. Used for progress visibility and logging (minimum 1). This does not affect concurrency; downloads are sequential. |
+| `--root` | `string` | — | Optional. Run the command from a different directory. |
+
+### Rate-limit handling
+
+When WordPress.org returns HTTP 429 (Too Many Requests), the `pup i18n` command handles it intelligently:
+
+**Backoff strategy:**
+- Uses exponential backoff with multipliers `[16, 31, 91, 151]` applied to the base `--delay`
+- 1st 429: `delay × 16` (e.g., 2s × 16 = 32s)
+- 2nd 429: `delay × 31` (e.g., 2s × 31 = 62s)
+- 3rd 429: `delay × 91` (e.g., 2s × 91 = 182s)
+- 4th 429: `delay × 151` (e.g., 2s × 151 = 302s)
+- Additional 429s: Use the same multiplier as the 4th (capped at highest in the schedule)
+
+**Server hints:**
+- If the response includes a `Retry-After` header (numeric seconds), the command respects it BUT caps it at the computed backoff wait time
+- Ensures we never wait longer than our backoff schedule allows
+- If `Retry-After` is an HTTP-date format, it is ignored and the backoff schedule is used instead
+
+**Retry consumption:**
+- Each HTTP 429 consumes one retry attempt from `--retries`
+- Non-429 failures (4xx/5xx errors, invalid responses) also consume retries and use the base `--delay`
+- Once `--retries` are exhausted, the download fails for that translation file
+
+**Example waits:**
+- With `--delay=2 --retries=3`: Up to 3 attempts (0, 1, 2); if all are 429s: 32s + 62s + 182s = ~4.6 minutes total
+- With `--delay=2 --retries=10`: Up to 10 attempts; if first 4 are 429s: 32s + 62s + 182s + 302s = ~9.6 minutes, then 5 more retries with base 2s delay
+
+**Example commands:**
+```bash
+# Conservative: fewer retries, longer delay between attempts
+pup i18n --retries=2 --delay=3
+
+# Aggressive: more retries, shorter delay (use with caution on rate-limited APIs)
+pup i18n --retries=5 --delay=1
+```
+
+## Configuration file options
 
 | Config option               | Type | Description                                                                                                                                       |
 |-----------------------------|---|---------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/pup
+++ b/pup
@@ -3,7 +3,7 @@
 
 namespace StellarWP\Pup;
 
-const PUP_VERSION = '1.3.8';
+const PUP_VERSION = '1.3.9';
 define( '__PUP_DIR__', __DIR__ );
 
 if ( ! \Phar::running() ) {

--- a/src/Commands/I18n.php
+++ b/src/Commands/I18n.php
@@ -3,7 +3,6 @@
 namespace StellarWP\Pup\Commands;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Request;
 use StellarWP\Pup\App;
 use StellarWP\Pup;
 use StellarWP\Pup\Command\Command;
@@ -14,9 +13,41 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class I18n extends Command {
 	/**
+	 * Number of retries per translation file (for non-429 failures).
+	 *
 	 * @var int
 	 */
 	protected $retries = 3;
+
+	/**
+	 * Base delay in seconds for backoff and between retries.
+	 *
+	 * @var int
+	 */
+	protected $delay = 2;
+
+	/**
+	 * Batch size for grouping downloads (for progress visibility, not concurrency).
+	 *
+	 * @var int
+	 */
+	protected $batch_size = 3;
+
+	/**
+	 * Maximum number of HTTP 429 retries per translation file.
+	 *
+	 * @var int
+	 */
+	protected $max_http_429_retries = 4;
+
+	/**
+	 * Backoff multipliers for HTTP 429 rate limit errors.
+	 * Index corresponds to the 429 attempt count (0-indexed).
+	 * Applied as: delay * multiplier.
+	 *
+	 * @var int[]
+	 */
+	protected $http_429_backoff_multipliers = [ 16, 31, 91, 151 ];
 
 	/**
 	 * @inheritDoc
@@ -25,7 +56,9 @@ class I18n extends Command {
 	 */
 	protected function configure() {
 		$this->setName( 'i18n' )
-			->addOption( 'retries', null, InputOption::VALUE_REQUIRED, 'How many retries we do for each file.' )
+			->addOption( 'retries', null, InputOption::VALUE_REQUIRED, 'How many retries per translation file.' )
+			->addOption( 'delay', null, InputOption::VALUE_REQUIRED, 'Delay (seconds) between retries and for 429 backoff.' )
+			->addOption( 'batch-size', null, InputOption::VALUE_REQUIRED, 'Batch size for grouping downloads.' )
 			->addOption( 'root', null, InputOption::VALUE_REQUIRED, 'Set the root directory for running commands.' )
 			->setDescription( 'Fetches language files for the project.' )
 			->setHelp( 'Fetches language files for the project.' );
@@ -35,11 +68,13 @@ class I18n extends Command {
 	 * @inheritDoc
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ) {
-		$config        = App::getConfig();
-		$io            = $this->getIO();
-		$root          = $input->getOption( 'root' );
-		$this->retries = $input->getOption( 'retries' ) ?? 3;
-		$i18n          = $config->getI18n();
+		$config         = App::getConfig();
+		$io             = $this->getIO();
+		$root           = $input->getOption( 'root' );
+		$this->retries  = max( 1, min( 10, (int) ( $input->getOption( 'retries' ) ?? 3 ) ) );
+		$this->delay    = max( 1, (int) ( $input->getOption( 'delay' ) ?? 2 ) );
+		$this->batch_size = max( 1, (int) ( $input->getOption( 'batch-size' ) ?? 3 ) );
+		$i18n           = $config->getI18n();
 
 		if ( $root ) {
 			chdir( $root );
@@ -48,7 +83,7 @@ class I18n extends Command {
 		foreach ( $i18n as $i18n_config ) {
 			$results = $this->download_language_files( $i18n_config );
 
-			if ( $results !== 0 ) {
+			if ( 0 !== $results ) {
 				$io->writeln( '<fg=red>Failed to download language files.</>' );
 				$io->writeln( '<fg=yellow>Config:</>' );
 				$io->writeln( (string) json_encode( $i18n_config, JSON_PRETTY_PRINT ) );
@@ -64,9 +99,9 @@ class I18n extends Command {
 	}
 
 	/**
-	 * Returns default client options.
+	 * Returns default Guzzle client options.
 	 *
-	 * @return array<string, array<string, string>>
+	 * @return array<string, mixed>
 	 */
 	protected function get_default_client_options() {
 		$version = Pup\PUP_VERSION;
@@ -74,17 +109,46 @@ class I18n extends Command {
 			'headers' => [
 				'User-Agent' => "StellarWP PUP/{$version}",
 			],
+			'http_errors' => false,
 		];
 	}
 
 	/**
-	 * Downloads language files.
+	 * Extracts wait time from Retry-After header if present.
+	 * Respects server hint but caps it to the fixed backoff schedule.
+	 *
+	 * @param \Psr\Http\Message\ResponseInterface $response
+	 * @param int $default_wait Default wait time in seconds.
+	 *
+	 * @return int Recommended wait time in seconds.
+	 */
+	protected function get_retry_after_delay( $response, $default_wait ) {
+		$retry_after = $response->getHeaderLine( 'Retry-After' );
+
+		if ( ! $retry_after ) {
+			return $default_wait;
+		}
+
+		// Retry-After can be seconds (numeric) or HTTP-date string.
+		if ( is_numeric( $retry_after ) ) {
+			$server_wait = (int) $retry_after;
+			// Use the smaller of server hint or our backoff; defer to server if more conservative.
+			return max( 1, min( $server_wait, $default_wait ) );
+		}
+
+		// If it's an HTTP-date, we'd need to parse it; for simplicity, use default.
+		return $default_wait;
+	}
+
+	/**
+	 * Downloads language files for a given I18n config.
+	 * Processes downloads sequentially with deterministic retry logic.
 	 *
 	 * @param I18nConfig $i18n_config
 	 *
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 *
-	 * @return int
+	 * @return int 0 on success, 1 on failure.
 	 */
 	protected function download_language_files( I18nConfig $i18n_config ): int {
 		$io      = $this->getIO();
@@ -109,116 +173,173 @@ class I18n extends Command {
 			$io->writeln( "<fg=red>Failed to fetch project data from {$project_url}</>", OutputInterface::VERBOSITY_VERBOSE );
 			return 1;
 		}
+
 		$project_data = json_decode( $project_res->getBody() );
-		$promises = [];
 
 		if ( empty( $project_data->translation_sets ) ) {
 			$io->writeln( "<fg=red>Failed to fetch translation sets from {$project_url}</>", OutputInterface::VERBOSITY_VERBOSE );
 			return 1;
 		}
 
+		// Build a list of (translation, format) pairs to download.
+		$download_items = [];
 		foreach ( $project_data->translation_sets as $translation ) {
-			// skip when translations are zero.
+			// Skip when translations are zero.
 			if ( 0 === $translation->current_count ) {
 				continue;
 			}
 
-			// Skip any translation set that doest match our min translated.
+			// Skip any translation set that doesn't match the minimum percentage.
 			if ( $options->filter['minimum_percentage'] > $translation->percent_translated ) {
 				continue;
 			}
 
 			foreach ( $options->formats as $format ) {
-				$promise = $this->download_and_save_translation( $options, $translation, $format, $project_url );
+				$download_items[] = [ $translation, $format ];
+			}
+		}
 
-				if ( null !== $promise ) {
-					$promises[] = $promise;
+		if ( empty( $download_items ) ) {
+			return 0;
+		}
+
+		// Process downloads sequentially in batches (for grouping/visibility).
+		$failed_count = 0;
+		$item_count   = count( $download_items );
+
+		for ( $offset = 0; $offset < $item_count; $offset += $this->batch_size ) {
+			$batch = array_slice( $download_items, $offset, $this->batch_size );
+
+			// Process each item in the batch sequentially.
+			foreach ( $batch as $item ) {
+				$translation = $item[0];
+				$format      = $item[1];
+
+				try {
+					$this->download_and_save_translation_sync( $client, $options, $translation, $format, $project_url );
+				} catch ( \Exception $e ) {
+					$io->writeln( "<fg=red>Download failed: {$e->getMessage()}</>" );
+					$failed_count++;
 				}
 			}
 		}
 
-		array_map( static function( $promise ) {
-			$promise->wait();
-		}, $promises );
-
-		return 0;
+		return $failed_count > 0 ? 1 : 0;
 	}
 
 	/**
-	 * Downloads and saves a translation.
+	 * Synchronously downloads and saves a translation with deterministic retry logic.
+	 * Handles both regular retries and HTTP 429 backoff.
 	 *
+	 * @param Client $client
 	 * @param \stdClass $options
 	 * @param \stdClass $translation
 	 * @param string $format
 	 * @param string $project_url
-	 * @param int $tried
 	 *
-	 * @return \GuzzleHttp\Promise\PromiseInterface|null
+	 * @throws \Exception On failure after all retries exhausted.
+	 *
+	 * @return void
 	 */
-	protected function download_and_save_translation( $options, $translation, $format, $project_url, $tried = 0 ) {
-		$io              = $this->getIO();
-		$translation_url = "{$project_url}/{$translation->locale}/{$translation->slug}/export-translations?format={$format}";
-		if ( $tried >= $this->retries ) {
-			$io->writeln( "<fg=red>Failed to fetch translation from {$translation_url} too many times, bailing on {$translation->slug}</>", OutputInterface::VERBOSITY_VERBOSE );
-			return null;
+	protected function download_and_save_translation_sync( $client, $options, $translation, $format, $project_url ) {
+		$io               = $this->getIO();
+		$translation_url  = "{$project_url}/{$translation->locale}/{$translation->slug}/export-translations?format={$format}";
+
+		// Outer loop: regular retries for non-429 failures.
+		for ( $tried = 0; $tried < $this->retries; $tried++ ) {
+			$http_429_count = 0;
+
+			// Inner loop: 429 retries with exponential backoff.
+			while ( $http_429_count < $this->max_http_429_retries ) {
+				$response    = $client->request( 'GET', $translation_url );
+				$status_code = $response->getStatusCode();
+				$body        = (string) $response->getBody();
+				$body_size   = strlen( $body );
+
+				// Handle HTTP 429 (Too Many Requests).
+				if ( 429 === $status_code ) {
+					$multiplier = $this->http_429_backoff_multipliers[ $http_429_count ];
+					$base_wait  = $this->delay * $multiplier;
+					$wait_time  = $this->get_retry_after_delay( $response, $base_wait );
+
+					$io->writeln(
+						"<fg=yellow>Rate limited (HTTP 429) on {$translation->slug}. Waiting {$wait_time}s before retry (attempt " . ( $http_429_count + 1 ) . '/' . $this->max_http_429_retries . ")...</>",
+						OutputInterface::VERBOSITY_VERBOSE
+					);
+
+					sleep( $wait_time );
+					$http_429_count++;
+					continue;
+				}
+
+				// Check for valid response.
+				if ( 200 !== $status_code || $body_size < 200 ) {
+					$io->writeln(
+						"<fg=red>Invalid response from {$translation_url} (status: {$status_code}, size: {$body_size})</>" ,
+						OutputInterface::VERBOSITY_VERBOSE
+					);
+					break; // Exit 429 loop; will retry with regular retry logic.
+				}
+
+				// Save the translation file and return on success.
+				$this->save_translation_file( $body, $options, $translation, $format );
+				return;
+			}
+
+			// If we get here, we either got a non-429 error or exhausted 429 retries.
+			// Try again with regular retry delay (if retries remaining).
+			if ( $tried < $this->retries - 1 ) {
+				$io->writeln(
+					"<fg=yellow>Retrying {$translation->slug} after {$this->delay}s...</>",
+					OutputInterface::VERBOSITY_VERBOSE
+				);
+				sleep( $this->delay );
+			}
 		}
 
-		$tried++;
+		// All retries exhausted.
+		throw new \Exception( "Failed to download {$translation->slug} after {$this->retries} retries" );
+	}
 
-		$client  = new Client( $this->get_default_client_options() );
-		$request = new Request( 'GET', $translation_url );
+	/**
+	 * Saves a translation to disk.
+	 *
+	 * @param string $content The translation content.
+	 * @param \stdClass $options
+	 * @param \stdClass $translation
+	 * @param string $format
+	 *
+	 * @throws \Exception On write failure.
+	 *
+	 * @return void
+	 */
+	protected function save_translation_file( $content, $options, $translation, $format ) {
+		$io = $this->getIO();
 
-		$promise = $client->sendAsync( $request )->then( function ( $response ) use ( $translation_url, $options, $translation, $format, $project_url, $tried, $io  ) {
-			$search = [
-				'%domainPath%',
-				'%textdomain%',
-				'%locale%',
-				'%wp_locale%',
-				'%format%',
-			];
-			$replace = [
-				$options->domain_path,
-				$options->text_domain,
-				$translation->locale ?? '',
-				$translation->wp_locale ?? '',
-				$format,
-			];
-			$filename = str_replace( $search, $replace, $options->file_format );
+		$search = [
+			'%domainPath%',
+			'%textdomain%',
+			'%locale%',
+			'%wp_locale%',
+			'%format%',
+		];
+		$replace = [
+			$options->domain_path,
+			$options->text_domain,
+			$translation->locale ?? '',
+			$translation->wp_locale ?? '',
+			$format,
+		];
+		$filename = str_replace( $search, $replace, $options->file_format );
 
-			$translation_body = $response->getBody();
-			$translation_size = $translation_body->getSize();
+		$file_path = "{$options->domain_path}/{$filename}";
+		$written   = file_put_contents( $file_path, $content );
 
-			if ( 200 > $translation_size ) {
-				$io->writeln( "<fg=red>Failed to fetch translation from {$translation_url}</>", OutputInterface::VERBOSITY_VERBOSE );
+		if ( false === $written || $written !== strlen( $content ) ) {
+			@unlink( $file_path );
+			throw new \Exception( "Failed to write translation to {$file_path}" );
+		}
 
-				// Not sure if 2seconds is needed, but it prevents the firewall from catching us.
-				sleep( 2 );
-
-				// Retries to download this file.
-				return $this->download_and_save_translation( $options, $translation, $format, $project_url, $tried );
-			}
-
-			$translation_content = $translation_body->getContents();
-			$file_path = "{$options->domain_path}/{$filename}";
-
-			$put_contents = file_put_contents( $file_path, $translation_content );
-
-			if ( $put_contents !== $translation_size ) {
-				$io->writeln( "<fg=red>Failed to save the translation from {$translation_url} to {$file_path}</>", OutputInterface::VERBOSITY_VERBOSE );
-
-				// Delete the file in that case.
-				@unlink( $file_path );
-
-				// Not sure if 2 seconds is needed, but it prevents the firewall from catching us.
-				sleep( 2 );
-
-				// Retries to download this file.
-				return $this->download_and_save_translation( $options, $translation, $format, $project_url, $tried );
-			}
-
-			$io->writeln( "* Translation created for <fg=green>{$file_path}</>" );
-		} );
-
-		return $promise;
+		$io->writeln( "* Translation created for <fg=green>{$file_path}</>" );
 	}
 }

--- a/src/Commands/I18n.php
+++ b/src/Commands/I18n.php
@@ -248,7 +248,7 @@ class I18n extends Command {
 			// Handle HTTP 429 (Too Many Requests) with smarter delay.
 			if ( 429 === $status_code ) {
 				// Use the backoff multiplier for this occurrence (0-indexed).
-				$multiplier = $this->http_429_backoff_multipliers[ $http_429_count ] ?? 151;
+				$multiplier = $this->http_429_backoff_multipliers[ $http_429_count ] ?? end( $this->http_429_backoff_multipliers );
 				$backoff_wait = $this->delay * $multiplier;
 				$wait_time    = $this->get_wait_time_for_429( $response, $backoff_wait );
 
@@ -271,6 +271,7 @@ class I18n extends Command {
 						OutputInterface::VERBOSITY_VERBOSE
 					);
 					sleep( $this->delay );
+					continue;
 				}
 				continue;
 			}

--- a/src/Commands/I18n.php
+++ b/src/Commands/I18n.php
@@ -273,7 +273,7 @@ class I18n extends Command {
 					sleep( $this->delay );
 					continue;
 				}
-				continue;
+				break;
 			}
 
 			// Success: save and return.


### PR DESCRIPTION
Improve the pup i18n command’s retry behavior when hitting WordPress.org rate limits (HTTP 429).

Previously, retries treated all failures the same, which could cause repeated rapid requests during rate limiting. This update introduces smarter handling for 429 responses while keeping the original retry flow intact for all other errors.