### PR TITLE
chore: bump pup const version to 2.0.0

### DIFF
--- a/pup
+++ b/pup
@@ -3,7 +3,7 @@
 
 namespace StellarWP\Pup;
 
-const PUP_VERSION = '1.3.9';
+const PUP_VERSION = '2.0.0';
 define( '__PUP_DIR__', __DIR__ );
 
 if ( ! \Phar::running() ) {


### PR DESCRIPTION
### Description

Apparently there is a `PUP_VERSION` constant in the pup file - this bumps it to `2.0.0` to match the current version.  I can do a tag patch or we can release `2.0.1`